### PR TITLE
Added validation to ensure username for cert-manager is 32 chars max

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -7,6 +7,10 @@ variable "username" {
   type        = string
   default     = "cert-manager-dns-admin"
   description = "Desired username for cert-manager DNS administrator user."
+  validation {
+    condition     = length(var.username) <= 32
+    error_message = "The username for cert-manager DNS administrator user may only be max 32 characters long."
+  }
 }
 
 variable "release_name" {


### PR DESCRIPTION
Username for DNS administrator user in the OTC cannot be longer than 32 characters. There should be a validation on the variable configuring this (username) to ensure lenght is within accepted limit.